### PR TITLE
return 404 on /api/messages and /api/inlets/default endpoints

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -104,6 +104,16 @@ func Poll() {
 	}()
 }
 
+
+func NotFound(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+
+	w.WriteHeader(http.StatusNotFound)
+}
+
 func Webhook(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		w.WriteHeader(http.StatusMethodNotAllowed)

--- a/main.go
+++ b/main.go
@@ -124,6 +124,8 @@ func main() {
 
 	// Register Routes
 	messageChain := alice.New(middleware.WithToken("recipient", config.KeyRecipient))
+	apiRouter.Methods(http.MethodGet, http.MethodPost).Path("/messages").HandlerFunc(api.NotFound)
+	apiRouter.Methods(http.MethodGet, http.MethodPost).Path("/inlets/default").HandlerFunc(api.NotFound)
 	apiRouter.Methods(http.MethodGet, http.MethodPost).Path("/messages/{recipient}").Handler(messageChain.Append(defaultIn.New().Handler).Then(messageHandler))
 	apiRouter.Methods(http.MethodGet, http.MethodPost).Path("/inlets/default/{recipient}").Handler(messageChain.Append(defaultIn.New().Handler).Then(messageHandler))
 	apiRouter.Methods(http.MethodGet, http.MethodPost).Path("/inlets/alertmanager/{recipient}").Handler(messageChain.Append(alertmanagerIn.New().Handler).Then(messageHandler))


### PR DESCRIPTION
Return 404 instead of 405 on `/api/messages` and `/api/inlets/default endpoints`
since "not found" is treated as "error" by `curl` and maybe other programs

( PR related to https://github.com/muety/telepush/issues/52 → #52 )